### PR TITLE
Add rough outline for non-component docs

### DIFF
--- a/projects/dev-docs/README.md
+++ b/projects/dev-docs/README.md
@@ -48,7 +48,7 @@ TODO: Outline how to change / update a new component doc
 
 #### Documenting exported functions and other objects
 
-TODO: Confirm if this will be a focus and which tools we will use. Will we build package docs indidually or can we build the whole monorepo together? Can we incorporate styleguide docs together or do we keep components separate?
+TODO: Confirm if this will be a focus and which tools we will use. Will we build package docs individually or can we build the whole monorepo together? Can we incorporate styleguide docs together or do we keep components separate?
 
 Topics to cover:
 

--- a/projects/dev-docs/README.md
+++ b/projects/dev-docs/README.md
@@ -45,3 +45,20 @@ Developer focused documentation to help us build nteract and enable more people 
 TODO: Outline how to start documenting a new component
 
 TODO: Outline how to change / update a new component doc
+
+#### Documenting exported functions and other objects
+
+TODO: Confirm if this will be a focus and which tools we will use. Will we build package docs indidually or can we build the whole monorepo together? Can we incorporate styleguide docs together or do we keep components separate?
+
+Topics to cover:
+
+- Link to and/or comment on how to write JSDoc style comments
+
+- Building docs with [documentation.js](https://github.com/documentationjs/documentation/blob/master/docs/GETTING_STARTED.md), for example:
+
+  ```
+  cd packages/core
+  documentation serve src/index.js
+  ```
+
+- [Adding a docstring above flow type annotations](https://github.com/documentationjs/documentation/blob/master/docs/GETTING_STARTED.md#flow-type-annotations)


### PR DESCRIPTION
I was looking into [`documentation.js`](http://documentation.js.org/) to see what we might be able to do with the existing JSDoc style docstrings in some of our packages. 

I found that there is already a lot of good content in packages like `@nteract/core` and that we can add some docstrings above our existing flow types to quickly generate some useful docs. (Probably while increasing our flow coverage as we go)

I added some of my thoughts to the README here, but also some questions like whether we will just focus on components or if documentation.js is a tool we will use.